### PR TITLE
POC of writing preview and thumbnail image in DNG file 

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 if(CXXIMG_WITH_DNG)
     set(DNG_THREAD_SAFE 0)
-    set(DNG_WITH_JPEG 0)
+    set(DNG_WITH_JPEG 1)
     set(DNG_WITH_XMP 0)
 
     FetchContent_Declare(


### PR DESCRIPTION
Hello,

One of  the users in python 'cxx-image-io' package wants export .dng file, but it often has some display issue in his image viewer or post processing software. 

I investigated and noticed our DngIO writes the .dng file however it contains only full-resolution image,  it isn't with thumbnail or preview image so it is reason why some image viewer refuse to open or display it.

I happened to find part of code in dng_validate.cpp that generates the thumbnail and preview image.
it has 2 steps : 
1. build stage2 and stage3 images, 
2. based on the stage3 RGB image it rends a 256 width's thumbnail and a JPEG compressed 1024 width's preview.
3. append some relative exif of previews.

I tested this branch with the dng file you gave to me, then have a preview and thumbnail.
![views](https://github.com/user-attachments/assets/429cfc7a-07e5-4bdc-b252-bf081e46e628)


Here is some thumbnail and preview information in exif:
 
![preview_exif](https://github.com/user-attachments/assets/50aa40a1-2da4-4c15-930a-c4a8c80ee05b)
![thumbnail_exif](https://github.com/user-attachments/assets/4d438c57-3acc-46b2-9fc3-981fae828c81)



